### PR TITLE
Refer to new version of subsonic

### DIFF
--- a/subsonic/README.md
+++ b/subsonic/README.md
@@ -1,5 +1,6 @@
 # Tags and Dockerfiles
-- `6.1.3`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.3`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
 - `6.1.2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.2/subsonic/Dockerfile))
 - `6.1.1`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.1/subsonic/Dockerfile))
 - `6.0.beta2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.0.beta2/subsonic/Dockerfile))

--- a/subsonic/README.md
+++ b/subsonic/README.md
@@ -1,5 +1,5 @@
 # Tags and Dockerfiles
-- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.5/subsonic/Dockerfile))
 - `6.1.3`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
 - `6.1.2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.2/subsonic/Dockerfile))
 - `6.1.1`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.1/subsonic/Dockerfile))

--- a/subsonic/docker-compose.yml
+++ b/subsonic/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: ./
       args:
-        SUBSONIC_VERSION: 6.1.3
-    image: danisla/subsonic:6.1.3
+        SUBSONIC_VERSION: 6.1.5
+    image: danisla/subsonic:6.1.5
     restart: always
     volumes:
       - /store/subsonic-state:/opt/app/state:rw


### PR DESCRIPTION
Version 6.1.5 has been out a while now. 

You will need to update the tag on your repo.

Thanks for the initial work.