### PR TITLE
Update subsonic to 6.1.5.

### DIFF
--- a/subsonic/Dockerfile
+++ b/subsonic/Dockerfile
@@ -31,9 +31,9 @@ RUN wget "https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-$
   dpkg -i /tmp/subsonic.deb && \
   rm -rf /tmp/subsonic.deb
 
-RUN wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz -O /tmp/ffmpeg-release-64bit-static.tar.xz && \
+RUN wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O /tmp/ffmpeg-release-amd64-static.tar.xz && \
   mkdir -p /opt/ffmpeg && \
-  tar xf /tmp/ffmpeg-release-64bit-static.tar.xz -C /opt/ffmpeg --strip-components=1
+  tar xf /tmp/ffmpeg-release-amd64-static.tar.xz -C /opt/ffmpeg --strip-components=1
 
 WORKDIR /opt/app
 ENV SUBSONIC_CONTEXT_PATH /

--- a/subsonic/README.md
+++ b/subsonic/README.md
@@ -1,5 +1,6 @@
 # Tags and Dockerfiles
-- `6.1.3`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.3`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
 - `6.1.2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.2/subsonic/Dockerfile))
 - `6.1.1`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.1/subsonic/Dockerfile))
 - `6.0.beta2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.0.beta2/subsonic/Dockerfile))

--- a/subsonic/README.md
+++ b/subsonic/README.md
@@ -1,5 +1,5 @@
 # Tags and Dockerfiles
-- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
+- `6.1.5`, `latest`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.5/subsonic/Dockerfile))
 - `6.1.3`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.3/subsonic/Dockerfile))
 - `6.1.2`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.2/subsonic/Dockerfile))
 - `6.1.1`, ([Dockerfile](https://github.com/danisla/dockerfiles/blob/subsonic-6.1.1/subsonic/Dockerfile))

--- a/subsonic/docker-compose.yml
+++ b/subsonic/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: ./
       args:
-        SUBSONIC_VERSION: 6.1.3
-    image: danisla/subsonic:6.1.3
+        SUBSONIC_VERSION: 6.1.5
+    image: danisla/subsonic:6.1.5
     restart: always
     volumes:
       - /store/subsonic-state:/opt/app/state:rw


### PR DESCRIPTION
Building the Docker container for Subsonic does not work anymore. It fails with the following error:
```
ERROR: Service 'subsonic' failed to build: The command '/bin/sh -c wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz -O /tmp/ffmpeg-release-64bit-static.tar.xz &&   mkdir -p /opt/ffmpeg &&   tar xf /tmp/ffmpeg-release-64bit-static.tar.xz -C /opt/ffmpeg --strip-components=1' returned a non-zero code: 8
```

This pull request fixes the link to the static ffmpeg resource and bumps the subsonic version to 6.1.5.

Your Subsonic Docker setup is much appreciated. I'm running the Dockerfile as proposed by this pull request myself (different docker-compose.yml though but also version 6.1.5).

I did not update the file `README.md`.